### PR TITLE
Adding typings to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "local.js",
     "sync.js",
     "utils.js",
-    "browser.js"
+    "browser.js",
+    "typings/localforage-webextensionstorage-driver.d.ts"
   ],
   "author": "Espen Henriksen",
   "license": "MIT",


### PR DESCRIPTION
Thanks for adding TypeScript typings! However, they are not accessible when you install via npm, as they are not included in the bundle. This PR fixes that :)