### PR TITLE
Fixed return behaviour of getItem

### DIFF
--- a/__tests__/local.test.js
+++ b/__tests__/local.test.js
@@ -89,7 +89,7 @@ describe('local', () => {
     it('should remove an item from the store and call callback', () => {
       const spy = jest.fn();
       return testStore.getItem('foo', spy).then(() => {
-        expect(spy).toHaveBeenCalledWith('qrux');
+        expect(spy).toHaveBeenCalledWith(null, 'qrux');
         expect(window.chrome.storage.local.get).toHaveBeenCalledWith('foo');
       });
     });

--- a/__tests__/local.test.js
+++ b/__tests__/local.test.js
@@ -103,6 +103,19 @@ describe('local', () => {
         expect(result).toEqual('qrux');
       });
     });
+
+    it('should return null in callback and promise if data is not set', () => {
+      const spy = jest.fn();
+      testStore.getItem('bar', spy).then((promiseResult) => {
+
+        // validate callback
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(null, null); // first null for no error, second for ret
+
+        // validate promise
+        expect(promiseResult).toBeNull();
+      });
+    });
   });
 
   describe('key', () => {

--- a/__tests__/local.test.js
+++ b/__tests__/local.test.js
@@ -106,7 +106,7 @@ describe('local', () => {
 
     it('should return null in callback and promise if data is not set', () => {
       const spy = jest.fn();
-      testStore.getItem('bar', spy).then((promiseResult) => {
+      return testStore.getItem('bar', spy).then((promiseResult) => {
 
         // validate callback
         expect(spy).toHaveBeenCalledTimes(1);
@@ -217,4 +217,3 @@ describe('local', () => {
     });
   });
 });
-

--- a/__tests__/sync.test.js
+++ b/__tests__/sync.test.js
@@ -89,7 +89,7 @@ describe('sync', () => {
     it('should remove an item from the store and call callback', () => {
       const spy = jest.fn();
       return testStore.getItem('foo', spy).then(() => {
-        expect(spy).toHaveBeenCalledWith('qrux');
+        expect(spy).toHaveBeenCalledWith(null, 'qrux');
         expect(window.chrome.storage.sync.get).toHaveBeenCalledWith('foo');
       });
     });
@@ -101,6 +101,19 @@ describe('sync', () => {
       return result.then(result => {
         expect(window.chrome.storage.sync.get).toHaveBeenCalledWith('foo');
         expect(result).toEqual('qrux');
+      });
+    });
+
+    it('should return null in callback and promise if data is not set', () => {
+      const spy = jest.fn();
+      return testStore.getItem('bar', spy).then((promiseResult) => {
+
+        // validate callback
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(null, null); // first null for no error, second for ret
+
+        // validate promise
+        expect(promiseResult).toBeNull();
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Espen Henriksen",
   "license": "MIT",
   "peerDependencies": {
-    "localforage": "^1.1.0"
+    "localforage": "^1.7.4"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",
@@ -38,7 +38,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.6.0",
     "jest": "^18.1.0",
-    "localforage": "^1.4.3"
+    "localforage": "^1.7.4"
   },
   "jest": {
     "testURL": "https://www.example.com",

--- a/src/driver.js
+++ b/src/driver.js
@@ -39,6 +39,7 @@ export default function createDriver(name, property) {
     async getItem(key, callback) {
       let result = await usePromise(get, key);
       result = typeof key === 'string' ? result[key] : result;
+      result = result === undefined ? null : result;
 
       if (callback) callback(result);
       return result;

--- a/src/driver.js
+++ b/src/driver.js
@@ -37,12 +37,22 @@ export default function createDriver(name, property) {
     },
 
     async getItem(key, callback) {
-      let result = await usePromise(get, key);
-      result = typeof key === 'string' ? result[key] : result;
-      result = result === undefined ? null : result;
+      try {
+        let result = await usePromise(get, key);
+        result = typeof key === 'string' ? result[key] : result;
+        result = result === undefined ? null : result;
 
-      if (callback) callback(result);
-      return result;
+        if (callback) callback(null, result);
+        return result;
+      }
+      catch (e) {
+        if (callback) {
+          callback(e);
+        }
+        else {
+          throw e;
+        }
+      }
     },
 
     async key(n, callback) {


### PR DESCRIPTION
We tried to gather a value from localforage running the webExtensionStorage-driver via the `getItem`-method with a key where we know that no value was set at present. As [localforage](https://github.com/localForage/localForage) indicates it brings the [LocalStorage specification](https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem) to any storage component.

> localForage improves the offline experience of your web app by using asynchronous storage (IndexedDB or WebSQL) with a simple, localStorage-like API.

Thus, we expected it to return a `null` value when no data was set under the given key, as we also observed from previous drivers:

- IndexedDB: https://github.com/localForage/localForage/blob/abe16c8a20c78ecff359647ede8e97f6102601b5/src/drivers/indexeddb.js#L518
- LocalStorage: https://github.com/localForage/localForage/blob/abe16c8a20c78ecff359647ede8e97f6102601b5/src/drivers/localstorage.js#L96 (returns automatically null in undefined cases, as defined by the above specification)
- WebSQL: 
https://github.com/localForage/localForage/blob/abe16c8a20c78ecff359647ede8e97f6102601b5/src/drivers/websql.js#L140, resp. https://github.com/localForage/localForage/blob/abe16c8a20c78ecff359647ede8e97f6102601b5/src/drivers/websql.js#L142

As we experienced the WebExtensionStorage driver returned unexpectedly an `undefined`. Hence, we add this use-case to your tests and fixed the behaviour.

Appreciate to see your feedback.
Cheers