### PR TITLE
Fixed iterator behaviour as in other lf drivers

### DIFF
--- a/__tests__/local.test.js
+++ b/__tests__/local.test.js
@@ -1,7 +1,8 @@
 import localforage from 'localforage';
 
 import localDriver from '../src/local';
-import resetMocks from '../setupTests.js';
+import resetMocks from '../setupTests';
+import iterator from '../lib/testIterator';
 
 beforeEach(resetMocks);
 
@@ -166,13 +167,6 @@ describe('local', () => {
   describe('iterate', () => {
     it('should iterate over the store and call callback', () => {
       const spy = jest.fn();
-      const iterator = (item, i) => {
-        if (i === 0) {
-          expect(item).toEqual({ foobar: 'duffman' });
-        } else {
-          expect(item).toEqual({ walpole: 'shiv' });
-        }
-      };
 
       return testStore.iterate(iterator, spy).then(() => {
         expect(spy).toHaveBeenCalled();
@@ -181,13 +175,6 @@ describe('local', () => {
     });
 
     it('should iterate over the store and call promise', () => {
-      const iterator = (item, i) => {
-        if (i === 0) {
-          expect(item).toEqual({ foobar: 'duffman' });
-        } else {
-          expect(item).toEqual({ walpole: 'shiv' });
-        }
-      };
       const result = testStore.iterate(iterator);
       expect(result).toBeInstanceOf(Promise);
 

--- a/__tests__/sync.test.js
+++ b/__tests__/sync.test.js
@@ -1,7 +1,8 @@
 import localforage from 'localforage';
 
 import syncDriver from '../src/sync';
-import resetMocks from '../setupTests.js';
+import resetMocks from '../setupTests';
+import iterator from '../lib/testIterator';
 
 beforeEach(resetMocks);
 
@@ -166,13 +167,6 @@ describe('sync', () => {
   describe('iterate', () => {
     it('should iterate over the store and call callback', () => {
       const spy = jest.fn();
-      const iterator = (item, i) => {
-        if (i === 0) {
-          expect(item).toEqual({ foobar: 'duffman' });
-        } else {
-          expect(item).toEqual({ walpole: 'shiv' });
-        }
-      };
 
       return testStore.iterate(iterator, spy).then(() => {
         expect(spy).toHaveBeenCalled();
@@ -181,13 +175,6 @@ describe('sync', () => {
     });
 
     it('should iterate over the store and call promise', () => {
-      const iterator = (item, i) => {
-        if (i === 0) {
-          expect(item).toEqual({ foobar: 'duffman' });
-        } else {
-          expect(item).toEqual({ walpole: 'shiv' });
-        }
-      };
       const result = testStore.iterate(iterator);
       expect(result).toBeInstanceOf(Promise);
 

--- a/lib/testIterator.js
+++ b/lib/testIterator.js
@@ -1,0 +1,18 @@
+const iterator = (value, key, i) => {
+  switch (i) {
+    case 0:
+      expect(value).toEqual('duffman');
+      expect(key).toEqual('foobar');
+      expect(i).toBe(0);
+      break;
+    case 1:
+      expect(value).toEqual('shiv');
+      expect(key).toEqual('walpole');
+      expect(i).toEqual(1);
+      break;
+    default:
+      throw new Error(`Did not expect an item ${i} in the iterator!`);
+  }
+};
+
+export default iterator;

--- a/src/driver.js
+++ b/src/driver.js
@@ -31,7 +31,7 @@ export default function createDriver(name, property) {
     async iterate(iterator, callback) {
       const items = await usePromise(get, null);
       const keys = Object.keys(items);
-      keys.forEach((key, i) => iterator({ [key]: items[key] }, i));
+      keys.forEach((key, i) => iterator(items[key], key, i));
 
       if (callback) callback();
     },
@@ -44,12 +44,10 @@ export default function createDriver(name, property) {
 
         if (callback) callback(null, result);
         return result;
-      }
-      catch (e) {
+      } catch (e) {
         if (callback) {
           callback(e);
-        }
-        else {
+        } else {
           throw e;
         }
       }


### PR DESCRIPTION
I discovered issues, that the iterator method returns the item and iterator itself, as in

- https://github.com/localForage/localForage/blob/c1cc34fda0343c5e19224fc99c452dbe611c1736/src/drivers/indexeddb.js#L572
- https://github.com/localForage/localForage/blob/c1cc34fda0343c5e19224fc99c452dbe611c1736/src/drivers/localstorage.js#L146
- https://github.com/localForage/localForage/blob/c1cc34fda0343c5e19224fc99c452dbe611c1736/src/drivers/websql.js#L196

The iterator should be a method, which takes `value, key, i` as parameters. This branch will fix the problem.